### PR TITLE
feat: add getDefaultICloudContainerPath method

### DIFF
--- a/ios/CloudStore.m
+++ b/ios/CloudStore.m
@@ -23,6 +23,7 @@ RCT_EXTERN_METHOD(kvGetAllItems :(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(getICloudURL :(NSString)containerIdentifier resolver:(RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(isICloudAvailable :(RCTPromiseResolveBlock)resolve                                     rejecter: (RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getDefaultICloudContainerPath :(RCTPromiseResolveBlock)resolve                                     rejecter: (RCTPromiseRejectBlock)reject)
 
 // file
 RCT_EXTERN_METHOD(writeFile: (NSString)path withContent:(NSString)content with:(NSDictionary)options resolver:(RCTPromiseResolveBlock)resolve

--- a/ios/CloudStore.swift
+++ b/ios/CloudStore.swift
@@ -164,6 +164,13 @@ extension CloudStoreModule {
         let token = FileManager.default.ubiquityIdentityToken
         resolve(token != nil)
     }
+
+    @objc
+    func getDefaultICloudContainerPath(_ resolve: RCTPromiseResolveBlock,
+                           rejecter reject: RCTPromiseRejectBlock) {
+        let path = FileManager.default.url(forUbiquityContainerIdentifier: nil)?.path ?? ""
+        resolve(path)
+    }
 }
 
 // MARK: icloud file functions

--- a/src/icloud.ts
+++ b/src/icloud.ts
@@ -11,6 +11,10 @@ function getConstants(): {
 
 export const defaultICloudContainerPath = getConstants().defaultICloudContainerPath
 
+export async function getDefaultICloudContainerPath(): Promise<string | undefined> {
+  return Platform.OS === 'ios' && CloudStore.getDefaultICloudContainerPath();
+}
+
 // https://developer.apple.com/documentation/foundation/filemanager/1411653-url
 export async function getICloudURL(containerIdentifier?: string): Promise<string> {
   return CloudStore.getICloudURL(containerIdentifier);


### PR DESCRIPTION
For https://app.asana.com/0/1200171328979524/1204142321655947

The `defaultICloudContainerPath` is not a constant, every time you enable/disable iCloud Drive, the value will change.  This causes problems when the user sets up iCloud Drive for the first time or changes the settings when the app is open.

Steps to test or reproduce the error

1. System Settings - iCloud Drive: off
2. Open the app
3. CloudStore.defaultICloudContainerPath returns ''
4. System Settings - iCloud Drive: on
5. Switch back to the app, do not restart the app
6. CloudStore.defaultICloudContainerPath returns '' -> error
7. CloudStore.getDefaultICloudContainerPath() returns correct path

Also happens

1. Simulator hard reset
2. Login Apple Account (iOS is preparing the iCloud Drive)
3. Open the App
4. CloudStore.defaultICloudContainerPath returns '' -> error

Didn't remove the `CloudStore.defaultICloudContainerPath` for backward compatibility.